### PR TITLE
Fix crashes with rubidium 0.2.13 (mc1.16.5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,8 +130,8 @@ dependencies {
 
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    compileOnly fg.deobf("curse.maven:magnesium-532724:3526076")
-    runtimeOnly fg.deobf("curse.maven:magnesium-532724:3526076")
+    compileOnly fg.deobf("curse.maven:rubidium-574856:4743730")
+    runtimeOnly fg.deobf("curse.maven:rubidium-574856:4743730")
 
     runtimeOnly fg.deobf("curse.maven:jei-238222:3438494")
     runtimeOnly fg.deobf("curse.maven:jer-240630:3066754")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon = false
 mod_id = dynamiclightsreforged
 mod_version = 1.0.1
 minecraft_version = 1.16.5
-forge_version = 36.2.0
+forge_version = 36.2.39
 
 mappings_version=2021.10.17-1.16.5
 mappings_channel=parchment

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,4 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'dynamiclightsreforged'
+rootProject.name = 'DynamicLightsReforged'

--- a/src/main/java/me/lambdaurora/lambdynlights/mixin/sodium/SodiumSettingsMixin.java
+++ b/src/main/java/me/lambdaurora/lambdynlights/mixin/sodium/SodiumSettingsMixin.java
@@ -13,10 +13,9 @@ import me.lambdaurora.lambdynlights.DynamicLightsReforged;
 import me.lambdaurora.lambdynlights.config.DynamicLightsConfig;
 import me.lambdaurora.lambdynlights.config.QualityMode;
 import net.minecraft.client.gui.screen.Screen;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Pseudo;
-import org.spongepowered.asm.mixin.Shadow;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -30,10 +29,11 @@ import java.util.List;
 @Mixin(SodiumOptionsGUI.class)
 public abstract class SodiumSettingsMixin {
 
-    @Shadow
+    @Shadow(remap = false)
     @Final
     private List<OptionPage> pages;
 
+    @Unique
     private static final SodiumOptionsStorage dynamicLightsOpts = new SodiumOptionsStorage();
 
 
@@ -48,7 +48,11 @@ public abstract class SodiumSettingsMixin {
                         "\n\nLighting recalculation can be expensive, so slower values will give better performance." +
                         "\n\nOff - Self explanatory\nSlow - Twice a second\nFast - Five times a second\nRealtime - Every tick")
                 .setControl(
-                        (option) -> new CyclingControl<>(option, QualityMode.class, new String[] { "Off", "Slow", "Fast", "Realtime" }))
+                        (option) -> new CyclingControl<>(option, QualityMode.class, new ITextComponent[] {
+                                new StringTextComponent("Off"),
+                                new StringTextComponent("Slow"),
+                                new StringTextComponent("Fast"),
+                                new StringTextComponent("Realtime") }))
                 .setBinding(
                         (options, value) -> {
                             DynamicLightsConfig.Quality.set(value.toString());


### PR DESCRIPTION
Environment:
- forge-1.16.5-36.2.39-client.jar
- dynamiclightsreforged-mc1.16.5_v1.0.1.jar          
- rubidium-mc1.16.5-0.2.13.jar

Crash when clicking on "Video Settings":
```
java.lang.NoSuchMethodError: 'void me.jellysquid.mods.sodium.client.gui.options.control.CyclingControl.<init>(me.jellysquid.mods.sodium.client.gui.options.Option, java.lang.Class, java.lang.String[])'
	at me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI.md2d1653$lambda$DynamicLights$0$6(SodiumOptionsGUI.java:551) ~[rubidium:?] {re:mixin,re:classloading,pl:mixin:APP:dynamiclightsreforged.mixins.json:sodium.SodiumSettingsMixin,pl:mixin:A}
	at me.jellysquid.mods.sodium.client.gui.options.OptionImpl.<init>(OptionImpl.java:49) ~[rubidium:?] {re:mixin,re:classloading}
	at me.jellysquid.mods.sodium.client.gui.options.OptionImpl.<init>(OptionImpl.java:17) ~[rubidium:?] {re:mixin,re:classloading}
	at me.jellysquid.mods.sodium.client.gui.options.OptionImpl$Builder.build(OptionImpl.java:214) ~[rubidium:?] {re:mixin,re:classloading}
	at me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI.handler$zzl000$DynamicLights(SodiumOptionsGUI.java:559) ~[rubidium:?] {re:mixin,re:classloading,pl:mixin:APP:dynamiclightsreforged.mixins.json:sodium.SodiumSettingsMixin,pl:mixin:A}
	at me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI.<init>(SodiumOptionsGUI.java:58) ~[rubidium:?] {re:mixin,re:classloading,pl:mixin:APP:dynamiclightsreforged.mixins.json:sodium.SodiumSettingsMixin,pl:mixin:A}
	at net.minecraft.client.gui.screen.OptionsScreen.handler$zcl000$open(OptionsScreen.java:523) ~[?:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:rubidium.mixins.json:features.options.MixinOptionsScreen,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.OptionsScreen.func_213059_g(OptionsScreen.java) ~[?:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:rubidium.mixins.json:features.options.MixinOptionsScreen,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.widget.button.Button.func_230930_b_(SourceFile:33) ~[?:?] {re:classloading,pl:accesstransformer:B,re:mixin,pl:accesstransformer:B}
	at net.minecraft.client.gui.widget.button.AbstractButton.func_230982_a_(SourceFile:16) ~[?:?] {re:classloading}
	at net.minecraft.client.gui.widget.Widget.func_231044_a_(Widget.java:136) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.INestedGuiEventHandler.func_231044_a_(SourceFile:27) ~[?:?] {re:mixin,re:computing_frames,re:classloading}
	at net.minecraft.client.MouseHelper.func_198033_b(MouseHelper.java:87) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screen.Screen.func_231153_a_(Screen.java:427) ~[?:?] {re:mixin,pl:runtimedistcleaner:A,re:computing_frames,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.func_198023_a(MouseHelper.java:85) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHelper.func_228030_c_(MouseHelper.java:181) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.execute(SourceFile:94) ~[?:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B}
	at net.minecraft.client.MouseHelper.func_228028_b_(MouseHelper.java:180) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
```