### PR TITLE
Add minVersion to mixins.json

### DIFF
--- a/src/main/resources/dynamiclightsreforged.mixins.json
+++ b/src/main/resources/dynamiclightsreforged.mixins.json
@@ -24,6 +24,7 @@
     "lightsource.TntEntityMixin",
     "sodium.SodiumSettingsMixin"
   ],
+  "minVersion": "0.7",
   "mixins": [
     "sodium.ArrayLightDataCacheMixin",
     "sodium.FlatLightPipelineMixin",


### PR DESCRIPTION
Saw this in my client logs and figured I might as well submit a fix.

Related issue is #16 but I hesitate to say this "fixes" it, because this is targeted at the 1.20 branch, not the 1.19 branch, since that seems dead? 